### PR TITLE
Missing assert dependency when using react native

### DIFF
--- a/bluzelle-js/communication.js
+++ b/bluzelle-js/communication.js
@@ -1,5 +1,4 @@
 const WebSocket = require('isomorphic-ws');
-const assert = require('assert');
 
 const connections = new Set();
 const resolvers = new Map();
@@ -81,8 +80,8 @@ const onMessage = (event, socket) => {
 
 
 
-// const disconnect = () => 
-//     Promise.all(Array.from(connections).map(con => 
+// const disconnect = () =>
+//     Promise.all(Array.from(connections).map(con =>
 //         new Promise(resolve => {
 
 //         con.onclose = () => {
@@ -252,8 +251,8 @@ const update = (key, value) => new Promise((resolve, reject) => {
 
         } else {
 
-            const pollingFunc = () => 
-                new Promise((res, rej) => 
+            const pollingFunc = () =>
+                new Promise((res, rej) =>
                     read(key).then(v => res(v === value), rej));
 
             poll(pollingFunc).then(resolve, reject);
@@ -282,8 +281,8 @@ const create = (key, value) => new Promise((resolve, reject) => {
 
         } else {
 
-            const pollingFunc = () => 
-                new Promise((res, rej) => 
+            const pollingFunc = () =>
+                new Promise((res, rej) =>
                     has(key).then(v => res(v), rej));
 
             poll(pollingFunc).then(resolve, reject);
@@ -314,8 +313,8 @@ const remove = key => new Promise((resolve, reject) => {
 
         } else {
 
-            const pollingFunc = () => 
-                new Promise((res, rej) => 
+            const pollingFunc = () =>
+                new Promise((res, rej) =>
                     has(key).then(v => res(!v), rej));
 
             poll(pollingFunc).then(resolve, reject);

--- a/bluzelle-js/package.json
+++ b/bluzelle-js/package.json
@@ -16,7 +16,6 @@
   "author": "Monty Thibault, John Lam",
   "license": "ISC",
   "dependencies": {
-    "assert": "^1.4.1",
     "base64-arraybuffer": "^0.1.5",
     "buffer": "^5.1.0",
     "isomorphic-ws": "^4.0.0",

--- a/bluzelle-js/package.json
+++ b/bluzelle-js/package.json
@@ -16,6 +16,7 @@
   "author": "Monty Thibault, John Lam",
   "license": "ISC",
   "dependencies": {
+    "assert": "^1.4.1",
     "base64-arraybuffer": "^0.1.5",
     "buffer": "^5.1.0",
     "isomorphic-ws": "^4.0.0",


### PR DESCRIPTION
<img width="277" alt="screen shot 2018-04-28 at 3 17 37 pm" src="https://user-images.githubusercontent.com/22436372/39401402-445cb080-4af9-11e8-9287-cb08e09c07e5.png">

Unused assert module is causing some issue in react-native.